### PR TITLE
Specifying exact dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,16 +2,16 @@
 , "description": "maptail geoips your tail -f to a map"
 , "version": "0.0.5"
 , "author": "George Stagas <gstagas@gmail.com> (http://stagas.com/)"
-, "repository": 
+, "repository":
   { "type": "git"
   , "url": "git://github.com/stagas/maptail.git"
   }
 , "bin": { "maptail": "./maptail.js" }
 , "dependencies":
-  { "express": ">=2.0.0"
-  , "geoip": ">=0.3.1"
-  , "socket.io": ">=0.6.0"
-  , "jade": ">=0.10.4"
+  { "express": "=2.0.0"
+  , "geoip": "=0.3.1"
+  , "socket.io": "=0.6.0"
+  , "jade": "=0.10.4"
   }
 , "engines": { "node": ">=0.4.0" }
 }


### PR DESCRIPTION
Hey,

There have been non-backwards-compatible changes in a number of the dependencies, including socket.io and geoip.  Locking down the dependency versions so it's easier to install without issues.  Thanks,

-nick
